### PR TITLE
Upload and Search static pdf from xblock

### DIFF
--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -29,6 +29,11 @@ class PdfBlock(
     completion_mode = XBlockCompletionMode.COMPLETABLE
 
     '''
+    Defualt Strings
+    '''
+    UPLOAD_URL = "/assets/{course_id}/?sort=uploadDate&direction=desc&asset_type=Documents&page_size=150"
+
+    '''
     Fields
     '''
     display_name = String(
@@ -128,8 +133,11 @@ class PdfBlock(
         The secondary view of the XBlock, shown to teachers
         when editing the XBlock.
         """
+        upload_url = self.UPLOAD_URL.format(course_id=str(self.course_id))
         context = {
             'display_name': self.display_name,
+            'course_id': self.course_id,
+            'upload_url': upload_url,
             'name_help': _("This name appears in the horizontal navigation at the top of the page."),
             'url': self.url,
             'allow_download': self.allow_download,
@@ -142,6 +150,7 @@ class PdfBlock(
             i18n_service=self.i18n_service,
         )
         frag = Fragment(html)
+        frag.add_css(self.load_resource("static/css/pdf_edit.css"))
         frag.add_javascript(self.load_resource("static/js/pdf_edit.js"))
         frag.initialize_js('pdfXBlockInitEdit')
         return frag

--- a/pdf/static/css/pdf_edit.css
+++ b/pdf/static/css/pdf_edit.css
@@ -1,0 +1,14 @@
+.upload-button {
+  transition: all 0.15s;
+  text-align: center;
+  border-radius: 5px;
+  border: 1px solid #0075b4;
+  padding: 1px 10px 2px 10px;
+  background-color: #fff;
+  color: #0075b4;
+}
+
+.upload-button:hover {
+  background-color: #0075b4;
+  color: #fff;
+}

--- a/pdf/static/js/pdf_edit.js
+++ b/pdf/static/js/pdf_edit.js
@@ -1,5 +1,25 @@
 /* Javascript for pdfXBlock. */
 function pdfXBlockInitEdit(runtime, element) {
+    function local_pdf_assets() {
+        const upload_url = $('#upload_url').val()
+        var req = jQuery.ajax({
+            url: upload_url,
+            method: 'GET',
+            dataType: "json",
+        });
+
+        req.then(function(response) {
+            $.each(response.assets, function (i, item) {
+                $('#suggestions').append($('<option>', { 
+                    value: item.portable_url,
+                    text : item.display_name 
+                }));
+            });
+        }, function(error) {
+            console.error('failed to fetch assets', error)
+        })
+    }
+
     $(element).find('.action-cancel').bind('click', function () {
         runtime.notify('cancel', {});
     });
@@ -25,4 +45,32 @@ function pdfXBlockInitEdit(runtime, element) {
             }
         });
     });
+
+    $(element).find('.action-upload').on('change', function (event) {
+        const file = event.target.files[0];
+        const formData = new FormData();
+        formData.set('file', file);
+
+        const upload_url = $('#upload_url').val()
+
+        var req = jQuery.ajax({
+            url: upload_url,
+            method: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false
+        });
+
+        req.then(function(response) {
+            document.getElementById("pdf_edit_url").value = response.asset.portable_url;
+            $('#suggestions').append($('<option>', { 
+                value: response.asset.portable_url.portable_url,
+                text : response.asset.portable_url.display_name 
+            }));
+        }, function(error) {
+            console.error('faild to upload pdf', error)
+        })
+    });
+
+    local_pdf_assets();
 }

--- a/pdf/templates/html/pdf_edit.html
+++ b/pdf/templates/html/pdf_edit.html
@@ -3,7 +3,7 @@
 
 <div class="wrapper-comp-settings editor-with-buttons is-active" id="settings-tab">
   <ul class="list-input settings-list">
-
+    <input type="hidden" id="upload_url" name="upload_url" value="{{ upload_url }}">
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
         <label class="label setting-label" for="pdf_edit_display_name">{% trans "Name" %}</label>
@@ -14,10 +14,14 @@
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="pdf_edit_url">{% trans "PDF URL" %}</label>
-        <input class="input setting-input" id="pdf_edit_url" value="{{ url }}" type="text">
+        <label class="label setting-label" for="pdf_edit_url">{% trans "ADD PDF" %}</label>
+        <input class="input setting-input" autoComplete="on" list="suggestions" id="pdf_edit_url" value="{{ url }}" type="text">
+        <datalist id="suggestions">
+        </datalist>
+        <input class="action-upload" type="file" accept="application/pdf" id="myFile" style="display: none;">
+        <button class="upload-button" onclick="document.getElementById('myFile').click();">{% trans 'Upload PDF' %}</button>
       </div>
-      <span class="tip setting-help">{% trans "The URL of the PDF file" %}</span>
+      <span class="tip setting-help">{% trans "Add or search the URL or upload the PDF" %}</span>
     </li>
 
     <li class="field comp-setting-entry is-set">
@@ -29,7 +33,7 @@
         </select>
       </div>
       <span class="tip setting-help">{% trans "Display a download button for this PDF." %}</span>
-    </li
+    </li>
 
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">


### PR DESCRIPTION
#### This PR provides the solution to the issue mentioned in [Open edX Roadmap
](https://github.com/orgs/openedx/projects/4/views/1)

[Ticket 56](https://github.com/openedx/platform-roadmap/issues/56)
 
#### Instructors can directly upload pdf by clicking the `Upload PDF` button
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/88362079/187167733-7dd0aab3-71c6-47cf-890b-4a9c38e9e4d8.png">

#### Instructors can also search the filename/url from already uploaded pdfs
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/88362079/187168081-4bee4861-9b16-4690-970c-9836ed6bde57.png">

